### PR TITLE
"licenses" is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ var spdxLicenseIds = require('spdx-license-ids'); //=> ['Glide', 'Abstyles', 'AF
 
 ## License
 
-[The Uicense](./LICENSE).
+[The Unlicense](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
     "coverage": "node --harmony_arrow_functions node_modules/.bin/istanbul cover test.js",
     "coveralls": "${npm_package_scripts_coverage} && istanbul-coveralls"
   },
-  "licenses": [
-    {
-      "type": "Unlicense",
-      "url": "https://github.com/shinnn/spdx-license-ids/blob/master/LICENSE"
-    }
-  ],
+  "license": "Unlicense",
   "main": "spdx-license-ids.json",
   "files": [
     "spdx-license-ids.json"


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#license
"Unlicense" is a valid [SPDX identifier](https://spdx.org/licenses/Unlicense)
