### PR TITLE
Update repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "spdx-license-ids",
 	"version": "3.0.5",
 	"description": "A list of SPDX license identifiers",
-	"repository": "shinnn/spdx-license-ids",
+	"repository": "jslicense/spdx-license-ids",
 	"author": "Shinnosuke Watanabe (https://github.com/shinnn)",
 	"license": "CC0-1.0",
 	"scripts": {


### PR DESCRIPTION
This tiny PR updates the repository property of `package.json` to reflect the move to @jslicense.